### PR TITLE
Feat/fix build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=3s --start-period=20s \
   CMD node -e "require('http').get('http://127.0.0.1:3000',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
 
-CMD ["node","server.js"]
+CMD ["pnpm","start"]


### PR DESCRIPTION
This pull request updates the Docker container startup command to use the project's package manager script instead of running the server directly. This change helps ensure that all project-specific startup steps defined in the `start` script are executed.

- Dockerfile update:
  * Changed the container's default command from running `server.js` directly with Node to using `pnpm start`, which will execute the `start` script defined in `package.json`.